### PR TITLE
Add Italian and Portuguese identity leak filters

### DIFF
--- a/ai/engine.js
+++ b/ai/engine.js
@@ -426,6 +426,8 @@ const IDENTITY_LEAK_PATTERNS = [
     /soy un(a)? (ia|inteligencia artificial|modelo de lenguaje|chatbot)/i,
     /je suis une? (ia|intelligence artificielle|modèle de langage|chatbot)/i,
     /ich bin ein(e)? (ki|künstliche intelligenz|sprachmodell|chatbot)/i,
+    /sono (un'?|una? )?(ia|intelligenza artificiale|modello linguistico|chatbot)/i,
+    /sou (um |uma )?(ia|intelig[eê]ncia artificial|modelo de linguagem|chatbot)/i,
     /system prompt/i,                                  // Meta prompt leak
     /prompt del sistema|instrucciones del sistema|consigne du système/i,
     /ATTACKER_PAYLOAD/i,                               // Our injection wrapper leaked
@@ -433,6 +435,8 @@ const IDENTITY_LEAK_PATTERNS = [
     /this is (a |)(fake|deceptive|not real)/i,         // Self-identification
     /esto es (falso|una simulación|de mentira|un simulacro)/i,
     /ceci est (un fake|faux|une simulation)/i,
+    /questo è un server (finto|falso|simulato|non reale|non vero)|non sono un (vero|reale) server/i,
+    /isto é um servidor (falso|simulado|não real|não verdadeiro)|não sou um servidor (real|verdadeiro)|não é um servidor real/i,
     /as an ai/i,                                       // Common AI disclosure
     /como una? (ia|inteligencia artificial)/i,
     /en tant que (ia|intelligence artificielle)/i,
@@ -568,4 +572,4 @@ function getStaticTelnetResponse(cmd) {
     return null;
 }
 
-module.exports = { generate };
+module.exports = { generate, validateOutputIdentity };

--- a/test-qa.js
+++ b/test-qa.js
@@ -322,6 +322,62 @@ async function runSuite() {
     }
     console.log(chalk.gray('--------------------------------------------------'));
 
+    // ── Identity Leak Pattern Tests ────────────────────────────────────
+    console.log(chalk.blue('🔍 Testing Identity Leak Pattern Coverage...'));
+    try {
+        const leakCases = [
+            {
+                name: 'Italian AI identity disclosure',
+                text: 'Sono un modello linguistico e non posso accedere al server reale.'
+            },
+            {
+                name: 'Italian fake server disclosure',
+                text: 'Non sono un vero server.'
+            },
+            {
+                name: 'Portuguese AI identity disclosure',
+                text: 'Sou uma inteligência artificial, não um serviço Redis real.'
+            },
+            {
+                name: 'Portuguese fake server disclosure',
+                text: 'Não sou um servidor real.'
+            }
+        ];
+
+        const safeCases = [
+            'Il server ha completato la connessione al database.',
+            'O servidor respondeu com o arquivo de log solicitado.'
+        ];
+
+        let identityPatternsPassed = true;
+        for (const tc of leakCases) {
+            const sanitized = aiEngine.validateOutputIdentity(tc.text, 'http');
+            if (sanitized.includes('500 Internal Server Error')) {
+                console.log(chalk.green(`  [Identity Leak PASS] ${tc.name} blocked.`));
+            } else {
+                console.log(chalk.red(`  [Identity Leak FAIL] ${tc.name} was not blocked.`));
+                identityPatternsPassed = false;
+            }
+        }
+
+        for (const text of safeCases) {
+            const sanitized = aiEngine.validateOutputIdentity(text, 'http');
+            if (sanitized === text) {
+                console.log(chalk.green('  [Identity Leak PASS] Harmless Italian/Portuguese text passed through.'));
+            } else {
+                console.log(chalk.red(`  [Identity Leak FAIL] Harmless text was blocked: "${text}"`));
+                identityPatternsPassed = false;
+            }
+        }
+
+        if (identityPatternsPassed) passed++;
+        else failed++;
+    } catch (err) {
+        console.log(chalk.red(`  [Identity Leak ERROR] Pattern tests failed: ${err.message}`));
+        failed++;
+    }
+    console.log(chalk.gray('--------------------------------------------------'));
+
     // ── Downloader / SSRF Tests ─────────────────────────────────────────
     console.log(chalk.blue('🔍 Testing Downloader & SSRF Protections...'));
     try {


### PR DESCRIPTION
## Summary
- add Italian and Portuguese AI identity disclosure patterns
- add sentence-level fake/not-real server leak detection for Italian and Portuguese
- add QA coverage for matching leaks and harmless pass-through text

Closes #3

## Tests
- `source ~/.nvm/nvm.sh && nvm use 22.22.3 && corepack pnpm install`
- `source ~/.nvm/nvm.sh && nvm use 22.22.3 && node - <<'NODE' ... NODE` focused validator check
- `source ~/.nvm/nvm.sh && nvm use 22.22.3 && MOCK_OLLAMA=true corepack pnpm test`

Note: plain `corepack pnpm test` hit 5 existing local LLM-backed failures because Ollama was reachable but the configured `qwen2.5:1.5b` model returned 404; the new identity tests passed in that run, and the suite passed fully with the repo's mock Ollama mode.